### PR TITLE
ROCANA-9283: gowinlog passes subscribed channel

### DIFF
--- a/event.go
+++ b/event.go
@@ -119,7 +119,7 @@ func CreateListener(channel, query string, startpos EVT_SUBSCRIBE_FLAGS, watcher
 }
 
 // Get a handle for an event log subscription on the given channel. Will begin at the
-// bookmarked event, or the closest possible event if the log has been truncated. 
+// bookmarked event, or the closest possible event if the log has been truncated.
 // `query` is an XPath expression to filter the events on the channel - "*" allows all events.
 // The resulting handle must be closed with CloseEventHandle.
 func CreateListenerFromBookmark(channel, query string, watcher *LogEventCallbackWrapper, bookmarkHandle BookmarkHandle) (ListenerHandle, error) {
@@ -284,6 +284,7 @@ func eventCallbackError(handle C.ULONGLONG, logWatcher unsafe.Pointer) {
 
 //export eventCallback
 func eventCallback(handle C.ULONGLONG, logWatcher unsafe.Pointer) {
-	watcher := (*LogEventCallbackWrapper)(logWatcher).callback
-	watcher.PublishEvent(EventHandle(handle))
+	wrapper := (*LogEventCallbackWrapper)(logWatcher)
+	watcher := wrapper.callback
+	watcher.PublishEvent(EventHandle(handle), wrapper.channel)
 }

--- a/structs.go
+++ b/structs.go
@@ -66,9 +66,10 @@ type BookmarkHandle uint64
 
 type LogEventCallback interface {
 	PublishError(error)
-	PublishEvent(EventHandle)
+	PublishEvent(EventHandle, string)
 }
 
 type LogEventCallbackWrapper struct {
 	callback LogEventCallback
+	channel  string
 }


### PR DESCRIPTION
When handling the `ForwardedEvents` channel, gowinlog would receive events from all sorts of channels (Application, Setup, System, etc), and would try to use the channel name to retrieve the handle for that channel bookmark. It would fail with messages like `No handle for channel bookmark Application`.

This PR saves the original channel `ForwardedEvents` into the callback wrapper which is passed through `EvtSubscribe`s callback as the context argument. Instead of using the channel from the event in `PublishEvent`, we use the channel discovered through the callback wrapper. This allows us to correctly save and retrieve bookmarks for `ForwardedEvents`, even though the events on the channel have their own distinct channels.