### PR TITLE
ROCANA-9328: WinLogEvent stores subscribed channel

### DIFF
--- a/event.go
+++ b/event.go
@@ -286,5 +286,5 @@ func eventCallbackError(handle C.ULONGLONG, logWatcher unsafe.Pointer) {
 func eventCallback(handle C.ULONGLONG, logWatcher unsafe.Pointer) {
 	wrapper := (*LogEventCallbackWrapper)(logWatcher)
 	watcher := wrapper.callback
-	watcher.PublishEvent(EventHandle(handle), wrapper.channel)
+	watcher.PublishEvent(EventHandle(handle), wrapper.subscribedChannel)
 }

--- a/event_test.go
+++ b/event_test.go
@@ -8,6 +8,10 @@ import (
 	"unsafe"
 )
 
+const (
+	SUBSCRIBED_CHANNEL = "test-channel"
+)
+
 type ProviderXml struct {
 	ProviderName    string `xml:"Name,attr"`
 	EventSourceName string `xml:"EventSourceName,attr"`
@@ -94,7 +98,7 @@ func TestXmlRenderMatchesOurs(t *T) {
 
 	logWatcher, err := NewWinLogWatcher()
 	defer logWatcher.Shutdown()
-	event, err := logWatcher.convertEvent(testEvent)
+	event, err := logWatcher.convertEvent(testEvent, SUBSCRIBED_CHANNEL)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -116,6 +120,7 @@ func TestXmlRenderMatchesOurs(t *T) {
 	assertEqual(event.ChannelText, eventXml.RenderingInfo.ChannelText, t)
 	assertEqual(event.ProviderText, eventXml.RenderingInfo.ProviderText, t)
 	assertEqual(event.Created.Format("2006-01-02T15:04:05.000000000Z"), eventXml.System.TimeCreated.SystemTime, t)
+	assertEqual(event.SubscribedChannel, SUBSCRIBED_CHANNEL, t)
 }
 
 func BenchmarkXmlDecode(b *B) {
@@ -164,7 +169,7 @@ func BenchmarkAPIDecode(b *B) {
 	defer CloseEventHandle(uint64(renderContext))
 	logWatcher, err := NewWinLogWatcher()
 	for i := 0; i < b.N; i++ {
-		_, err := logWatcher.convertEvent(testEvent)
+		_, err := logWatcher.convertEvent(testEvent, SUBSCRIBED_CHANNEL)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/structs.go
+++ b/structs.go
@@ -36,6 +36,10 @@ type WinLogEvent struct {
 	// Serialied XML bookmark to
 	// restart at this event
 	Bookmark string
+
+	// Subscribed channel from which the event was retrieved,
+	// which may be different than the event's channel
+	SubscribedChannel string
 }
 
 type channelWatcher struct {
@@ -70,6 +74,6 @@ type LogEventCallback interface {
 }
 
 type LogEventCallbackWrapper struct {
-	callback LogEventCallback
-	channel  string
+	callback          LogEventCallback
+	subscribedChannel string
 }


### PR DESCRIPTION
Passes the subscribed channel as part of the event. This allows gowinlog users to distinguish between events tagged with a channel (e.g. Application) and events forwarded to the channel (e.g. ForwardedEvents). Bookmarks should always be persisted with the subscribed channel and not the event's channel.