### PR TITLE
ROCANA-9317: Render event XML

### DIFF
--- a/event.go
+++ b/event.go
@@ -235,6 +235,17 @@ func RenderEventValues(renderContext SysRenderContext, eventHandle EventHandle) 
 	return values, nil
 }
 
+// Render the event as XML.
+func RenderEventXML(eventHandle EventHandle) (string, error) {
+	xml := C.RenderEventXML(C.ULONGLONG(eventHandle))
+	if xml == nil {
+		return "", GetLastError()
+	}
+	xmlString := C.GoString(xml)
+	C.free(unsafe.Pointer(xml))
+	return xmlString, nil
+}
+
 // Get a handle that represents the publisher of the event, given the rendered event values.
 func GetEventPublisherHandle(renderedFields RenderedFields) (PublisherHandle, error) {
 	handle := PublisherHandle(C.GetEventPublisherHandle(C.PVOID(renderedFields)))

--- a/event.h
+++ b/event.h
@@ -27,6 +27,10 @@ char* GetLastErrorString();
 // GetRendered<type>Value. Buffer must be freed by the caller.
 PVOID RenderEventValues(ULONGLONG hContext, ULONGLONG hEvent);
 
+// Render the event's XML body
+char* RenderEventXML(ULONGLONG hEvent);
+
+
 // Get the type of the variable at the given index in the array.
 // Possible types are EvtVarType*
 int GetRenderedValueType(PVOID pRenderedValues, int property);

--- a/structs.go
+++ b/structs.go
@@ -33,6 +33,9 @@ type WinLogEvent struct {
 	ProviderText string
 	IdText       string
 
+	// XML body
+	Xml string
+
 	// Serialied XML bookmark to
 	// restart at this event
 	Bookmark string

--- a/winlog.go
+++ b/winlog.go
@@ -138,6 +138,11 @@ func (self *WinLogWatcher) convertEvent(handle EventHandle, subscribedChannel st
 		return nil, fmt.Errorf("Failed to render event values: %v", err)
 	}
 
+	xml, err := RenderEventXML(handle)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to render event xml: %v", err)
+	}
+
 	/* If fields don't exist we include the nil value */
 	computerName, _ := RenderStringField(renderedFields, EvtSystemComputer)
 	providerName, _ := RenderStringField(renderedFields, EvtSystemProviderName)
@@ -165,6 +170,8 @@ func (self *WinLogWatcher) convertEvent(handle EventHandle, subscribedChannel st
 	Free(unsafe.Pointer(renderedFields))
 
 	event := WinLogEvent{
+		Xml: xml,
+
 		ProviderName: providerName,
 		EventId:      eventId,
 		Qualifiers:   qualifiers,


### PR DESCRIPTION
Renders the XML body and stores it in a `WinLogEvent`.