### PR TITLE
ROCANA-9536: Shutdown hangs with several channel subscriptions

### DIFF
--- a/event.c
+++ b/event.c
@@ -183,6 +183,8 @@ DWORD WINAPI SubscriptionCallback(EVT_SUBSCRIBE_NOTIFY_ACTION action, PVOID pCon
 	switch(action)
 	{
 		case EvtSubscribeActionError:
+		// In this case, hEvent is an error code, not a handle to an event
+		// https://msdn.microsoft.com/en-us/library/windows/desktop/aa385596(v=vs.85).aspx
 		eventCallbackError((ULONGLONG)hEvent, pContext);
 		break;
 

--- a/event.go
+++ b/event.go
@@ -288,9 +288,11 @@ func getTestEventHandle() (EventHandle, error) {
    Note: handles are only valid within the callback. Don't pass them out. */
 
 //export eventCallbackError
-func eventCallbackError(handle C.ULONGLONG, logWatcher unsafe.Pointer) {
+func eventCallbackError(errCode C.ULONGLONG, logWatcher unsafe.Pointer) {
 	watcher := (*LogEventCallbackWrapper)(logWatcher).callback
-	watcher.PublishError(fmt.Errorf("Event log callback got error: %v", GetLastError()))
+	// The provided errCode can be looked up in the Microsoft System Error Code table:
+	// https://msdn.microsoft.com/en-us/library/windows/desktop/ms681382(v=vs.85).aspx
+	watcher.PublishError(fmt.Errorf("Event log callback got error code: %v", errCode))
 }
 
 //export eventCallback

--- a/winlog.go
+++ b/winlog.go
@@ -166,7 +166,12 @@ func (self *WinLogWatcher) Shutdown() {
 }
 
 func (self *WinLogWatcher) PublishError(err error) {
-	self.errChan <- err
+	// Publish the received error to the errChan, but
+	// discard if shutdown is in progress
+	select {
+	case self.errChan <- err:
+	case <-self.shutdown:
+	}
 }
 
 func (self *WinLogWatcher) convertEvent(handle EventHandle, subscribedChannel string) (*WinLogEvent, error) {


### PR DESCRIPTION
This change avoids blocking on shutdown when errors are available on the channel. 

Also an improvement to error handling: according to the documentation, when the first argument provided to the subscription callback is `EvtSubscribeActionError`, the third argument is a Win32 error code, not an event handle. Further, `GetLastError()` does not describe the error code, but instead the error code can be looked up in the Microsoft System Error Code table (link provided in the PR).