### PR TITLE
ROCANA-9842: winlog returns correct error messages

### DIFF
--- a/event.c
+++ b/event.c
@@ -32,7 +32,6 @@ PVOID RenderEventValues(ULONGLONG hContext, ULONGLONG hEvent) {
 	dwBufferSize = dwUsed;
 	if (! EvtRender((EVT_HANDLE)hContext, (EVT_HANDLE)hEvent, EvtRenderEventValues, dwBufferSize, pRenderedValues, &dwUsed, &dwPropertyCount)){
 		free(pRenderedValues);
-		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 		return NULL;
 	}
 	return pRenderedValues;
@@ -56,7 +55,6 @@ char* RenderEventXML(ULONGLONG hEvent) {
 	dwBufferSize = dwUsed;
 	if (! EvtRender(NULL, (EVT_HANDLE)hEvent, EvtRenderEventXml, dwBufferSize, xmlWide, &dwUsed, 0)){
 		free(xmlWide);
-		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 		return NULL;
 	}
 
@@ -97,7 +95,6 @@ char* GetFormattedMessage(ULONGLONG hEventPublisher, ULONGLONG hEvent, int forma
 	decodeReturn = EvtFormatMessage((EVT_HANDLE)hEventPublisher, (EVT_HANDLE)hEvent, 0, 0, NULL, format, dwBufferSize, messageWide, &dwBufferUsed);
 	if (!decodeReturn) {
 		free(messageWide);
-		SetLastError(ERROR_NOT_ENOUGH_MEMORY);
 		return NULL;
 	}
 	size_t lenMessage = wcstombs(NULL, messageWide, 0) + 1;


### PR DESCRIPTION
`GetLastError()` is a <a href="https://msdn.microsoft.com/en-us/library/windows/desktop/ms679360(v=vs.85).aspx">Windows method</a> used by many Win32 API calls to store error codes.

This PR removes a few calls to `SetLastError()`, which is correctly used in some places (e.g. `malloc()` failures), but which incorrectly overwrite the encountered error code set by the Win32 API call. This change will allow us to gather the actual error that occurred during event rendering and other tasks.