### PR TITLE
ROCANA-9899: Custom winlog events dropped when publisher missing

### DIFF
--- a/structs.go
+++ b/structs.go
@@ -9,32 +9,35 @@ import (
 // Stores the common fields from a log event
 type WinLogEvent struct {
 	// From EvtRender
-	ProviderName string
-	EventId      uint64
-	Qualifiers   uint64
-	Level        uint64
-	Task         uint64
-	Opcode       uint64
-	Created      time.Time
-	RecordId     uint64
-	ProcessId    uint64
-	ThreadId     uint64
-	Channel      string
-	ComputerName string
-	Version      uint64
+	ProviderName      string
+	EventId           uint64
+	Qualifiers        uint64
+	Level             uint64
+	Task              uint64
+	Opcode            uint64
+	Created           time.Time
+	RecordId          uint64
+	ProcessId         uint64
+	ThreadId          uint64
+	Channel           string
+	ComputerName      string
+	Version           uint64
+	RenderedFieldsErr error
 
 	// From EvtFormatMessage
-	Msg          string
-	LevelText    string
-	TaskText     string
-	OpcodeText   string
-	Keywords     []string
-	ChannelText  string
-	ProviderText string
-	IdText       string
+	Msg                string
+	LevelText          string
+	TaskText           string
+	OpcodeText         string
+	Keywords           []string
+	ChannelText        string
+	ProviderText       string
+	IdText             string
+	PublisherHandleErr error
 
 	// XML body
-	Xml string
+	Xml    string
+	XmlErr error
 
 	// Serialied XML bookmark to
 	// restart at this event


### PR DESCRIPTION
Adds partial rendering support when an error is encountered during rendering. Rather than exit `convertEvent()` on the first error, we store any errors alongside the rest of the attributes in `WinLogEvent`.

The primary use case is to avoid dropping the event when useful information can still be obtained. For example, if the publisher metadata is missing (e.g. producing application is not installed), the values and XML can still be rendered.